### PR TITLE
Fix minor option issues.

### DIFF
--- a/qdu.py
+++ b/qdu.py
@@ -84,6 +84,11 @@ class Args(object):
         except getopt.GetoptError, msg:
             print msg
             print __doc__
+            try:
+                # os.EX_USAGE exists only on Unix systems
+                sys.exit(os.EX_USAGE)
+            except:
+                sys.exit(1)
 
         if _arg: self.files = _arg
 
@@ -104,7 +109,11 @@ class Args(object):
             elif opt in ("--pass", "-p"):
                 self.passwd = arg
             else:
-                sys.exit(1)
+                try:
+                    # os.EX_USAGE exists only on Unix systems
+                    sys.exit(os.EX_USAGE)
+                except:
+                    sys.exit(1)
 
 #### Subroutines
 def login(host, user, passwd, port):

--- a/qdu.py
+++ b/qdu.py
@@ -12,12 +12,6 @@
 # the License.
 
 '''
-=== Required:
-
-[-i | --ip | --host] ip|hostname    An ip address or hostname of a node in
-                                        the cluster; use 'localhost' when
-                                        running directly on the node
-
 === Options:
 
  -s                                 Display an entry for each specified file.  (Equivalent to -d 0)


### PR DESCRIPTION
The __doc__ text here was a little misleading, specifying a required option that would trigger a failed parse if it was included (-i, --ip, --host). I added a program exit to sys.exit after a bad option was detected and changed the other one to use OS standard exit codes if available.